### PR TITLE
cleanup

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -1,7 +1,6 @@
 pub mod element;
 
 use Value;
-use Index;
 use sequence::uid::UID;
 use self::element::Element;
 use op::LocalOp;
@@ -22,7 +21,7 @@ impl Array {
         self.0.len() - 2
     }
 
-    pub fn insert(&mut self, index: Index, value: Value, replica: &Replica) -> Option<UpdateArray> {
+    pub fn insert(&mut self, index: usize, value: Value, replica: &Replica) -> Option<UpdateArray> {
         if index <= self.len() {
             let ref mut elements = self.0;
             let uid = {
@@ -39,7 +38,7 @@ impl Array {
         }
     }
 
-    pub fn delete(&mut self, index: Index) -> Option<UpdateArray> {
+    pub fn delete(&mut self, index: usize) -> Option<UpdateArray> {
         if index < self.len() {
             let element = self.0.remove(index+1);
             Some(UpdateArray::delete(element.uid))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,3 @@ pub use attributed_string::AttributedString;
 pub use object::Object;
 pub use replica::Replica;
 pub use value::Value;
-
-pub type Site = u32;
-pub type Counter = u32;
-pub type Index = usize;

--- a/src/object/element.rs
+++ b/src/object/element.rs
@@ -1,6 +1,5 @@
-use Counter;
 use object::uid::UID;
-use Site;
+use Replica;
 use Value;
 
 #[derive(Clone,PartialEq)]
@@ -10,15 +9,22 @@ pub struct Element {
 }
 
 impl Element {
-    pub fn new(key: &str, value: Value, site: Site, counter: Counter) -> Element {
-        let uid = UID::new(key, site, counter);
-        Element{uid: uid, value: value}
+    pub fn new(key: &str, value: Value, replica: &Replica) -> Element {
+        Element{uid: UID::new(key, replica), value: value}
     }
 }
 
-#[test]
-fn test_new() {
-    let val = Value::Str("bar".to_string());
-    let elt = Element::new("foo", val, 1, 1);
-    assert!(elt.value == Value::Str("bar".to_string()));
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use Replica;
+    use Value;
+
+    #[test]
+    fn test_new() {
+        let replica = Replica{site: 1, counter: 1};
+        let val = Value::Str("bar".to_string());
+        let elt = Element::new("foo", val, &replica);
+        assert!(elt.value == Value::Str("bar".to_string()));
+    }
 }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -5,11 +5,9 @@ pub use self::element::Element;
 pub use self::uid::UID;
 use std::collections::HashMap;
 use op::LocalOp;
-use op::local::Put;
-use op::local::Delete;
+use op::local::{Put,Delete};
 use op::remote::UpdateObject;
-use Counter;
-use Site;
+use Replica;
 use Value;
 
 #[derive(Clone)]
@@ -20,9 +18,9 @@ impl Object {
         Object(HashMap::new())
     }
 
-    pub fn put(&mut self, key: &str, value: Value, site: Site, counter: Counter) -> UpdateObject {
+    pub fn put(&mut self, key: &str, value: Value, replica: &Replica) -> UpdateObject {
         let mut elements = &mut self.0;
-        let new_element = Element::new(key, value, site, counter);
+        let new_element = Element::new(key, value, replica);
         let deleted_elts = elements.insert(key.to_string(), vec![new_element.clone()]);
         let deleted_uids = uids(deleted_elts);
         UpdateObject::new(key.to_string(), Some(new_element), deleted_uids)
@@ -115,91 +113,109 @@ fn uids(elements: Option<Vec<Element>>) -> Vec<UID> {
     }
 }
 
-#[test]
-fn test_new() {
-    let object = Object::new();
-    assert!(object.0.len() == 0);
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use op::remote::UpdateObject;
+    use op::local::Put;
+    use Replica;
+    use Value;
 
-#[test]
-fn test_put() {
-    let mut object = Object::new();
-    let op = object.put("foo", Value::Num(23.0), 1, 2);
+    const REPLICA: Replica = Replica{site: 1, counter: 2};
 
-    assert!(op.path == vec![]);
-    assert!(op.key == "foo".to_string());
-    assert!(op.new_element.unwrap().uid == UID::new("foo", 1, 2));
-    assert!(op.deleted_uids == vec![]);
-
-    assert!(object.0.get("foo").unwrap().len() == 1);
-    {
-        let element = object.get_by_key("foo").unwrap();
-        assert!(element.value == Value::Num(23.0));
+    #[test]
+    fn test_new() {
+        let object = Object::new();
+        assert!(object.0.len() == 0);
     }
-}
 
-#[test]
-fn test_delete() {
-    let mut object = Object::new();
-    let _  = object.put("bar", Value::Bool(true), 2, 4);
-    let op = object.delete("bar");
+    #[test]
+    fn test_put() {
+        let mut object = Object::new();
+        let op = object.put("foo", Value::Num(23.0), &REPLICA);
 
-    assert!(op.path == vec![]);
-    assert!(op.key == "bar".to_string());
-    assert!(op.new_element == None);
-    assert!(op.deleted_uids.len() == 1);
-    assert!(object.get_by_key("bar") == None);
-}
+        assert!(op.path == vec![]);
+        assert!(op.key == "foo".to_string());
+        assert!(op.new_element.unwrap().uid == UID::new("foo", &REPLICA));
+        assert!(op.deleted_uids == vec![]);
 
-#[test]
-fn test_execute_remote() {
-    let mut object = Object::new();
-    let elt = Element::new("baz", Value::Num(1.0), 2, 101);
-    let _   = object.put("baz", Value::Num(0.0), 3, 69);
-    let op2 = UpdateObject::new("baz".to_string(), Some(elt), vec![]);
-    let op3 = object.execute_remote(op2);
-    let op3_unwrapped = op3.as_any().downcast_ref::<Put>().unwrap();
+        assert!(object.0.get("foo").unwrap().len() == 1);
+        {
+            let element = object.get_by_key("foo").unwrap();
+            assert!(element.value == Value::Num(23.0));
+        }
+    }
 
-    assert!(op3_unwrapped.path == vec![]);
-    assert!(op3_unwrapped.key == "baz".to_string());
-    assert!(op3_unwrapped.value == Value::Num(1.0));
-    assert!(object.0.get("baz").unwrap().len() == 2);
-}
+    #[test]
+    fn test_delete() {
+        let mut object = Object::new();
+        let replica = Replica::new(2,4);
+        let _  = object.put("bar", Value::Bool(true), &replica);
+        let op = object.delete("bar");
 
-#[test]
-fn test_execute_remote_2() {
-    let mut object = Object::new();
-    let elt1 = Element::new("foo", Value::Bool(false), 1, 1);
-    let elt2 = Element::new("foo", Value::Bool(true), 2, 1);
-    let op1 = UpdateObject::new("foo".to_string(), Some(elt1.clone()), vec![]);
-    let op2 = UpdateObject::new("foo".to_string(), Some(elt2.clone()), vec![]);
-    let op3 = UpdateObject::new("foo".to_string(), None, vec![elt1.uid]);
+        assert!(op.path == vec![]);
+        assert!(op.key == "bar".to_string());
+        assert!(op.new_element == None);
+        assert!(op.deleted_uids.len() == 1);
+        assert!(object.get_by_key("bar") == None);
+    }
 
-    object.execute_remote(op1);
-    object.execute_remote(op2);
-    { assert!(object.get_by_key("foo").unwrap().value == Value::Bool(false)) }
+    #[test]
+    fn test_execute_remote() {
+        let mut object = Object::new();
+        let replica1 = Replica::new(2,101);
+        let replica2 = Replica::new(3,69);
+        let elt = Element::new("baz", Value::Num(1.0), &replica1);
+        let _   = object.put("baz", Value::Num(0.0), &replica2);
+        let op2 = UpdateObject::new("baz".to_string(), Some(elt), vec![]);
+        let op3 = object.execute_remote(op2);
+        let op3_unwrapped = op3.as_any().downcast_ref::<Put>().unwrap();
 
-    let op4 = object.execute_remote(op3);
-    let op4_unwrapped = op4.as_any().downcast_ref::<Put>().unwrap();
+        assert!(op3_unwrapped.path == vec![]);
+        assert!(op3_unwrapped.key == "baz".to_string());
+        assert!(op3_unwrapped.value == Value::Num(1.0));
+        assert!(object.0.get("baz").unwrap().len() == 2);
+    }
 
-    assert!(op4_unwrapped.path == vec![]);
-    assert!(op4_unwrapped.key == "foo".to_string());
-    assert!(op4_unwrapped.value == Value::Bool(true));
-}
+    #[test]
+    fn test_execute_remote_2() {
+        let mut object = Object::new();
+        let replica1 = Replica::new(1,1);
+        let replica2 = Replica::new(2,1);
+        let elt1 = Element::new("foo", Value::Bool(false), &replica1);
+        let elt2 = Element::new("foo", Value::Bool(true), &replica2);
+        let op1 = UpdateObject::new("foo".to_string(), Some(elt1.clone()), vec![]);
+        let op2 = UpdateObject::new("foo".to_string(), Some(elt2.clone()), vec![]);
+        let op3 = UpdateObject::new("foo".to_string(), None, vec![elt1.uid]);
 
-#[test]
-fn test_replace_by_key() {
-    let mut object = Object::new();
-    object.put("foo", Value::Num(1.0), 1, 1);
-    assert!(object.replace_by_key("foo", Value::Bool(true)));
-    assert!(object.get_by_key("foo").unwrap().value == Value::Bool(true));
-}
+        object.execute_remote(op1);
+        object.execute_remote(op2);
+        { assert!(object.get_by_key("foo").unwrap().value == Value::Bool(false)) }
 
-#[test]
-fn test_replace_by_uid() {
-    let mut object = Object::new();
-    let op1 = object.put("foo", Value::Num(1.0), 1, 1);
-    let uid = op1.new_element.unwrap().uid;
-    assert!(object.replace_by_uid(&uid, Value::Bool(true)));
-    assert!(object.get_by_uid(&uid).unwrap().value == Value::Bool(true));
+        let op4 = object.execute_remote(op3);
+        let op4_unwrapped = op4.as_any().downcast_ref::<Put>().unwrap();
+
+        assert!(op4_unwrapped.path == vec![]);
+        assert!(op4_unwrapped.key == "foo".to_string());
+        assert!(op4_unwrapped.value == Value::Bool(true));
+    }
+
+    #[test]
+    fn test_replace_by_key() {
+        let mut object = Object::new();
+        let replica = Replica::new(1,1);
+        object.put("foo", Value::Num(1.0), &replica);
+        assert!(object.replace_by_key("foo", Value::Bool(true)));
+        assert!(object.get_by_key("foo").unwrap().value == Value::Bool(true));
+    }
+
+    #[test]
+    fn test_replace_by_uid() {
+        let mut object = Object::new();
+        let replica = Replica::new(1,1);
+        let op1 = object.put("foo", Value::Num(1.0), &replica);
+        let uid = op1.new_element.unwrap().uid;
+        assert!(object.replace_by_uid(&uid, Value::Bool(true)));
+        assert!(object.get_by_uid(&uid).unwrap().value == Value::Bool(true));
+    }
 }

--- a/src/object/uid.rs
+++ b/src/object/uid.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use Replica;
 
 #[derive(Clone,Eq)]
 pub struct UID {
@@ -8,8 +9,8 @@ pub struct UID {
 }
 
 impl UID {
-    pub fn new(key: &str, site: u32, counter: u32) -> UID {
-        UID{key: key.to_string(), site: site, counter: counter}
+    pub fn new(key: &str, replica: &Replica) -> UID {
+        UID{key: key.to_string(), site: replica.site, counter: replica.counter}
     }
 }
 
@@ -21,15 +22,7 @@ impl PartialEq for UID {
 
 impl PartialOrd for UID {
     fn partial_cmp(&self, other: &UID) -> Option<Ordering> {
-        if self.site < other.site {
-            Some(Ordering::Less)
-        } else if self.site == other.site && self.counter < other.counter {
-            Some(Ordering::Less)
-        } else if self.site == other.site && self.counter == other.counter {
-            Some(Ordering::Equal)
-        } else {
-            Some(Ordering::Greater)
-        }
+        Some(self.cmp(other))
     }
 }
 
@@ -47,19 +40,29 @@ impl Ord for UID {
     }
 }
 
-#[test]
-fn test_new() {
-    let uid = UID::new("foo", 1, 23);
-    assert!(uid.key == String::from("foo"));
-    assert!(uid.site == 1);
-    assert!(uid.counter == 23);
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use Replica;
 
-#[test]
-fn test_equality() {
-    let uid1 = UID::new("foo", 1, 23);
-    let uid2 = UID::new("bar", 1, 23);
-    let uid3 = UID::new("foo", 2, 13);
-    assert!(uid1 == uid2);
-    assert!(uid1 != uid3);
+    #[test]
+    fn test_new() {
+        let replica = Replica{site: 1, counter: 23};
+        let uid = UID::new("foo", &replica);
+        assert!(uid.key == String::from("foo"));
+        assert!(uid.site == 1);
+        assert!(uid.counter == 23);
+    }
+
+    #[test]
+    fn test_equality() {
+        let replica1 = Replica::new(1, 23);
+        let replica2 = Replica::new(2, 13);
+
+        let uid1 = UID::new("foo", &replica1);
+        let uid2 = UID::new("bar", &replica1);
+        let uid3 = UID::new("foo", &replica2);
+        assert!(uid1 == uid2);
+        assert!(uid1 != uid3);
+    }
 }


### PR DESCRIPTION
- use Replica everywhere in function parameters
- ensure all tests are in test-specific modules
- remove unnecessary type aliases
- remove duplicate code
