### PR TITLE
validate NestedRemoteOp sites

### DIFF
--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -17,6 +17,13 @@ pub struct NestedRemoteOp {
 }
 
 impl NestedRemoteOp {
+    /// Returns true if the NestedRemoteOp's inserts all use
+    /// the given site; otherwise returns false.
+    pub fn validate(&self, site: u32) -> bool {
+        self.op.validate(site)
+    }
+
+    /// Reverses the NestedRemoteOp's effect
     pub fn reverse(&self) -> Self {
         NestedRemoteOp{pointer: self.pointer.clone(), op: self.op.reverse()}
     }

--- a/src/op/remote/increment_counter.rs
+++ b/src/op/remote/increment_counter.rs
@@ -1,5 +1,5 @@
 use Replica;
-use super::Reverse;
+use super::RemoteOpTrait;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct IncrementCounter {
@@ -7,11 +7,35 @@ pub struct IncrementCounter {
     pub replica: Replica,
 }
 
-impl Reverse for IncrementCounter {
+impl RemoteOpTrait for IncrementCounter {
+    fn validate(&self, site: u32) -> bool {
+        self.replica.site == site
+    }
+
     fn reverse(&self) -> Self {
         IncrementCounter {
             amount: -self.amount,
             replica: self.replica.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate() {
+        let op = IncrementCounter{amount: 1.0, replica: Replica::new(1,1)};
+        assert!(op.validate(1));
+        assert!(!op.validate(2));
+    }
+
+    #[test]
+    fn test_reverse() {
+        let op = IncrementCounter{amount: 1.0, replica: Replica::new(1,1)};
+        let op_reverse = op.reverse();
+        assert!(op_reverse.amount == -1.0);
+        assert!(op_reverse.replica == op.replica);
     }
 }

--- a/src/op/remote/mod.rs
+++ b/src/op/remote/mod.rs
@@ -17,6 +17,19 @@ pub enum RemoteOp {
 }
 
 impl RemoteOp {
+    pub fn validate(&self, site: u32) -> bool {
+        match *self {
+            RemoteOp::IncrementCounter(ref op) =>
+                op.validate(site),
+            RemoteOp::UpdateArray(ref op) =>
+                op.validate(site),
+            RemoteOp::UpdateAttributedString(ref op) =>
+                op.validate(site),
+            RemoteOp::UpdateObject(ref op) =>
+                op.validate(site),
+        }
+    }
+
     pub fn reverse(&self) -> Self {
         match *self {
             RemoteOp::IncrementCounter(ref op) =>
@@ -31,6 +44,7 @@ impl RemoteOp {
     }
 }
 
-pub trait Reverse {
+pub trait RemoteOpTrait {
+    fn validate(&self, site: u32) -> bool;
     fn reverse(&self) -> Self;
 }

--- a/src/op/remote/update_object.rs
+++ b/src/op/remote/update_object.rs
@@ -1,4 +1,4 @@
-use super::Reverse;
+use super::RemoteOpTrait;
 use object::Element;
 
 #[derive(Clone,PartialEq,Debug)]
@@ -21,15 +21,52 @@ impl UpdateObject {
             deletes: deleted_elements,
         }
     }
-
 }
 
-impl Reverse for UpdateObject {
+impl RemoteOpTrait for UpdateObject {
+    fn validate(&self, site: u32) -> bool {
+        for i in &self.inserts {
+            if i.uid.site != site { return false }
+        }
+        true
+    }
+
     fn reverse(&self) -> Self {
         UpdateObject{
             key: self.key.clone(),
             inserts: self.deletes.clone(),
             deletes: self.inserts.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate() {
+        let op1 = UpdateObject{
+            key: String::new(),
+            inserts: vec![element(55), element(55)],
+            deletes: vec![element(1), element(144)],
+        };
+
+        let op2 = UpdateObject{
+            key: String::new(),
+            inserts: vec![element(55), element(144)],
+            deletes: vec![element(1), element(144)],
+        };
+
+        assert!(op1.validate(55));
+        assert!(!op1.validate(144));
+        assert!(!op2.validate(55));
+        assert!(!op2.validate(144));
+    }
+
+    fn element(site: u32) -> Element {
+        use replica::Replica;
+        use value::Value;
+        Element::new("foo", Value::Num(1.0), &Replica::new(site,1))
     }
 }


### PR DESCRIPTION
Adds a function to validate that all inserts on a NestedRemoteOp come from a specific site.