### PR TITLE
encode and decode Counter CRDT

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -36,6 +36,14 @@ impl Counter {
             Some(Increment::new(op.amount))
         }
     }
+
+    pub fn replicas_vec(&self) -> Vec<Replica> {
+        let mut replicas = Vec::with_capacity(self.site_counters.len());
+        for (site, counter) in &self.site_counters {
+            replicas.push(Replica::new(*site, *counter))
+        }
+        replicas
+    }
 }
 
 #[cfg(test)]

--- a/src/serializer/decoder.rs
+++ b/src/serializer/decoder.rs
@@ -2,6 +2,7 @@ use array::Array;
 use array::element::Element as ArrayElement;
 use attributed_string::AttributedString;
 use attributed_string::element::Element as AttrStrElement;
+use counter::Counter;
 use object::element::Element as ObjectElement;
 use object::Object;
 use object::uid::UID as ObjectUID;
@@ -133,6 +134,16 @@ impl Deserialize for Value {
 
                         let object = Object::assemble(map);
                         Ok(Value::Obj(object))
+                    },
+                    3 => {
+                        let value: f64 = visitor.visit()?.ok_or(de::Error::missing_field("Counter value"))?;
+                        let replicas: Vec<Replica> = visitor.visit()?.ok_or(de::Error::missing_field("Counter replicas"))?;
+                        let mut site_counters = HashMap::new();
+                        for replica in replicas {
+                            site_counters.insert(replica.site, replica.counter);
+                        }
+                        let counter = Counter{value: value, site_counters: site_counters};
+                        Ok(Value::Counter(counter))
                     }
                     _ => return Err(de::Error::missing_field("invalid Value code")),
                 }

--- a/src/serializer/encoder.rs
+++ b/src/serializer/encoder.rs
@@ -106,7 +106,7 @@ impl Serialize for counter::Counter {
         let mut seq = serializer.serialize_seq(Some(3))?;
         seq.serialize_element(&3)?;
         seq.serialize_element(&self.value)?;
-        seq.serialize_element(&self.site_counters)?;
+        seq.serialize_element(&self.replicas_vec())?;
         seq.end()
     }
 }

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -6,6 +6,7 @@ mod tests {
     use array::Array;
     use attributed_string::AttributedString;
     use object::Object;
+    use counter::Counter;
     use op::{NestedRemoteOp, RemoteOp};
     use Replica;
     use serde_json;
@@ -53,6 +54,15 @@ mod tests {
         let encoded  = serde_json::to_string(&original).unwrap();
         let decoded: Value = serde_json::from_str(&encoded).unwrap();
         assert!(encoded == "\"hi!\"");
+        assert!(original == decoded);
+    }
+
+    #[test]
+    fn test_counter() {
+        let original = Value::Counter(Counter::new(123.0));
+        let encoded = serde_json::to_string(&original).unwrap();
+        let decoded: Value = serde_json::from_str(&encoded).unwrap();
+        assert!(encoded == "[3,123.0,[]]");
         assert!(original == decoded);
     }
 


### PR DESCRIPTION
Due to an oversight, encoding for Counter was implemented incorrectly and decoding was not implemented at all. Fixed!