### PR TITLE
remove CRDT value from public library interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ use ditto::List;
 
 // site 1 creates the CRDT and sends its original value to site 2.
 let mut list1: List<u32> = List::new();
-let mut list2: List<u32> = List::from_value(list1.clone_value(), 2);
+let mut list2: List<u32> = List::from_state(list1.clone_state(), 2);
 
 // each site concurrently inserts a different number at index 0
 let remote_op1 = list1.insert(0, 7).unwrap();

--- a/src/json.rs
+++ b/src/json.rs
@@ -639,7 +639,7 @@ mod tests {
     #[test]
     fn test_object_insert_awaiting_site() {
         let crdt1 = Json::from_str("{}").unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 0);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 0);
         let result = crdt2.object_insert("", "foo".to_owned(), 19.7);
 
         assert!(result.unwrap_err() == Error::AwaitingSite);
@@ -680,7 +680,7 @@ mod tests {
     #[test]
     fn test_object_remove_awaiting_site() {
         let crdt1 = Json::from_str(r#"{"abc":[1.5,true,{"def":false}]}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 0);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 0);
         assert!(crdt2.object_remove("/abc/2", "def").unwrap_err() == Error::AwaitingSite);
         assert!(crdt2.awaiting_site.len() == 1);
         assert!(nested_value(&mut crdt2, "/abc/2/def").is_none());
@@ -711,7 +711,7 @@ mod tests {
     #[test]
     fn test_array_insert_awaiting_site() {
         let crdt1 = Json::from_str(r#"{"things":[1,2,3]}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 0);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 0);
         assert!(crdt2.array_insert("/things", 1, true).unwrap_err() == Error::AwaitingSite);
         assert!(crdt2.awaiting_site.len() == 1);
         assert!(*nested_value(&mut crdt2, "/things/1").unwrap() == JsonValue::Bool(true));
@@ -742,7 +742,7 @@ mod tests {
     #[test]
     fn test_array_remove_awaiting_site() {
         let crdt1 = Json::from_str(r#"{"things":[1,[true,false,"hi"],2,3]}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 0);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 0);
         assert!(crdt2.array_remove("/things", 1).unwrap_err() == Error::AwaitingSite);
 
         let remote_op = crdt2.awaiting_site.pop().unwrap();
@@ -777,7 +777,7 @@ mod tests {
     #[test]
     fn test_string_insert_awaiting_site() {
         let remote_crdt = Json::from_str(r#"["hello",5.0]"#).unwrap();
-        let mut crdt = Json::from_value(remote_crdt.clone_value(), 0);
+        let mut crdt = Json::from_state(remote_crdt.clone_state(), 0);
         assert!(crdt.string_insert("/0", 0, "😗🇺🇸".to_owned()).unwrap_err() == Error::AwaitingSite);
         assert!(local_json(crdt.value()) == r#"["😗🇺🇸hello",5.0]"#);
 
@@ -813,7 +813,7 @@ mod tests {
     #[test]
     fn test_string_remove_awaiting_site() {
         let remote_crdt = Json::from_str(r#"[5.0,"hello"]"#).unwrap();
-        let mut crdt = Json::from_value(remote_crdt.clone_value(), 0);
+        let mut crdt = Json::from_state(remote_crdt.clone_state(), 0);
         assert!(crdt.string_remove("/1", 1, 2).unwrap_err() == Error::AwaitingSite);
         assert!(local_json(crdt.value()) == r#"[5.0,"hlo"]"#);
 
@@ -850,7 +850,7 @@ mod tests {
     #[test]
     fn test_string_replace_awaiting_site() {
         let remote_crdt = Json::from_str(r#"[5.0,"hello"]"#).unwrap();
-        let mut crdt = Json::from_value(remote_crdt.clone_value(), 0);
+        let mut crdt = Json::from_state(remote_crdt.clone_state(), 0);
         assert!(crdt.string_replace("/1", 1, 2, "åⱡ".to_owned()).unwrap_err() == Error::AwaitingSite);
         assert!(local_json(crdt.value()) == r#"[5.0,"håⱡlo"]"#);
 
@@ -864,7 +864,7 @@ mod tests {
     #[test]
     fn test_execute_remote_object() {
         let mut crdt1 = Json::from_str(r#"{"foo":[1.0,true,"hello"],"bar":null}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 0);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 0);
         let remote_op = crdt1.object_insert("", "baz".to_owned(), 54.0).unwrap();
         let local_op  = crdt2.execute_remote(&remote_op).unwrap();
 
@@ -875,7 +875,7 @@ mod tests {
     #[test]
     fn test_execute_remote_array() {
         let mut crdt1 = Json::from_str(r#"{"foo":[1.0,true,"hello"],"bar":null}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 0);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 0);
         let remote_op = crdt1.array_insert("/foo", 0, 54.0).unwrap();
         let local_op  = crdt2.execute_remote(&remote_op).unwrap();
 
@@ -886,7 +886,7 @@ mod tests {
     #[test]
     fn test_execute_remote_string() {
         let mut crdt1 = Json::from_str(r#"{"foo":[1.0,true,"hello"],"bar":null}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 0);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 0);
         let remote_op = crdt1.string_replace("/foo/2", 1, 2, "ab".to_owned()).unwrap();
         let local_op  = crdt2.execute_remote(&remote_op).unwrap();
 
@@ -897,7 +897,7 @@ mod tests {
     #[test]
     fn test_execute_remote_missing_pointer() {
         let mut crdt1 = Json::from_str(r#"{"foo":[1.0,true,"hello"],"bar":null}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 2);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 2);
         let remote_op = crdt1.object_remove("", "bar").unwrap();
         let _         = crdt2.object_remove("", "bar").unwrap();
         assert!(crdt2.execute_remote(&remote_op).is_none());
@@ -906,7 +906,7 @@ mod tests {
     #[test]
     fn test_merge() {
         let mut crdt1 = Json::from_str(r#"{"x":[{"a": 1},{"b": 2},{"c":true},{"d":false}]}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 2);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 2);
         let _ = crdt1.object_insert("/x/0", "e".to_owned(), 222.0);
         let _ = crdt1.object_insert("/x/3", "e".to_owned(), 333.0);
         let _ = crdt1.array_remove("/x", 2);
@@ -929,7 +929,7 @@ mod tests {
     #[test]
     fn test_add_site() {
         let crdt1 = Json::from_str(r#"{"foo":[1,2,3],"bar":"hello"}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 0);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 0);
         let _ = crdt2.object_insert("","baz".to_owned(), json!({"abc":[true, false, 84.0]}));
         let _ = crdt2.array_insert("/baz/abc", 1, 61.0);
         let _ = crdt2.string_insert("/bar", 5, " everyone!".to_owned());
@@ -991,7 +991,7 @@ mod tests {
     #[test]
     fn test_add_site_nested() {
         let crdt1 = Json::from_str("{}").unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 0);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 0);
         let _ = crdt2.object_insert("", "foo".to_owned(), json!({
             "a": [[1.0],["hello everyone!"],{"x": 3.0}],
             "b": {"cat": true, "dog": false}
@@ -1021,7 +1021,7 @@ mod tests {
     #[test]
     fn test_execute_remote_dupe() {
         let mut crdt1 = Json::from_str(r#"{"foo":[1.0,true,"hello"],"bar":null}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 0);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 0);
         let remote_op = crdt1.object_remove("", "bar").unwrap();
         assert!(crdt2.execute_remote(&remote_op).is_some());
         assert!(crdt2.execute_remote(&remote_op).is_none());
@@ -1073,7 +1073,7 @@ mod tests {
     #[test]
     fn test_serialize_local_op() {
         let mut crdt1 = Json::from_str(r#"{"foo":{}}"#).unwrap();
-        let mut crdt2 = Json::from_value(crdt1.clone_value(), 2);
+        let mut crdt2 = Json::from_state(crdt1.clone_state(), 2);
         let remote_op = crdt1.object_insert("/foo", "bar".to_owned(), json!({
             "a": [[1.0],["hello everyone!"],{"x": 3.0}],
             "b": {"cat": true, "dog": false}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,9 @@ pub use traits::{CrdtValue, CrdtRemoteOp};
 pub use error::Error;
 pub use replica::{Replica, Tombstones};
 
-pub use json::Json;
-pub use list::List;
-pub use map::Map;
-pub use register::{Register, RegisterValue};
-pub use set::Set;
-pub use text::Text;
+pub use json::{Json, JsonState};
+pub use list::{List, ListState};
+pub use map::{Map, MapState};
+pub use register::{Register, RegisterState};
+pub use set::{Set, SetState};
+pub use text::{Text, TextState};

--- a/src/list.rs
+++ b/src/list.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_insert_remove_awaiting_site() {
-        let mut list: List<i64> = List::from_value(ListValue::new(), 0);
+        let mut list: List<i64> = List::from_state(List::new().clone_state(), 0);
         assert!(list.insert(0, 123).unwrap_err() == Error::AwaitingSite);
         assert!(list.len() == 1);
         assert!(list.awaiting_site.len() == 1);
@@ -495,7 +495,7 @@ mod tests {
 
     #[test]
     fn test_add_site() {
-        let mut list: List<u32> = List::from_value(ListValue::new(), 0);
+        let mut list: List<u32> = List::from_state(List::new().clone_state(), 0);
         let _ = list.insert(0, 51);
         let _ = list.insert(1, 52);
         let _ = list.remove(0);
@@ -513,7 +513,7 @@ mod tests {
 
     #[test]
     fn test_add_site_already_has_site() {
-        let mut list: List<u32> = List::from_value(ListValue::new(), 12);
+        let mut list: List<u32> = List::from_state(List::new().clone_state(), 12);
         let _ = list.insert(0, 51);
         let _ = list.insert(1, 52);
         let _ = list.remove(0);
@@ -590,5 +590,4 @@ mod tests {
             RemoteOp::Insert(_) => panic!(),
         }
     }
-
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -447,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_insert_awaiting_site() {
-        let mut map: Map<u32, String> = Map::from_value(MapValue::new(), 0);
+        let mut map: Map<u32, String> = Map::from_state(Map::new().clone_state(), 0);
         assert!(map.insert(123, "abc".to_owned()).unwrap_err() == Error::AwaitingSite);
         assert!(map.get(&123).unwrap() == "abc");
         assert!(map.awaiting_site.len() == 1);
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn test_remove_awaiting_site() {
-        let mut map: Map<bool, i8> = Map::from_value(MapValue::new(), 0);
+        let mut map: Map<bool, i8> = Map::from_state(Map::new().clone_state(), 0);
         let _ = map.insert(true, 3);
         assert!(map.remove(&true).unwrap_err() == Error::AwaitingSite);
         assert!(map.get(&true).is_none());
@@ -482,7 +482,7 @@ mod tests {
     #[test]
     fn test_execute_remote_insert() {
         let mut map1: Map<i32, u64> = Map::new();
-        let mut map2: Map<i32, u64> = Map::from_value(MapValue::new(), 2);
+        let mut map2: Map<i32, u64> = Map::from_state(Map::new().clone_state(), 2);
         let remote_op = map1.insert(123, 1010).unwrap();
         let local_op  = map2.execute_remote(&remote_op).unwrap();
 
@@ -493,7 +493,7 @@ mod tests {
     #[test]
     fn test_execute_remote_insert_concurrent() {
         let mut map1: Map<i32, u64> = Map::new();
-        let mut map2: Map<i32, u64> = Map::from_value(MapValue::new(), 2);
+        let mut map2: Map<i32, u64> = Map::from_state(Map::new().clone_state(), 2);
         let remote_op1 = map1.insert(123, 2222).unwrap();
         let remote_op2 = map2.insert(123, 1111).unwrap();
         let local_op1  = map1.execute_remote(&remote_op2);
@@ -508,7 +508,7 @@ mod tests {
     #[test]
     fn test_execute_remote_insert_dupe() {
         let mut map1: Map<i32, u64> = Map::new();
-        let mut map2: Map<i32, u64> = Map::from_value(MapValue::new(), 2);
+        let mut map2: Map<i32, u64> = Map::from_state(Map::new().clone_state(), 2);
         let remote_op = map1.insert(123, 2222).unwrap();
         let _ = map2.execute_remote(&remote_op);
         assert!(map2.execute_remote(&remote_op).is_none());
@@ -517,7 +517,7 @@ mod tests {
     #[test]
     fn test_execute_remote_remove() {
         let mut map1: Map<i32, u64> = Map::new();
-        let mut map2: Map<i32, u64> = Map::from_value(MapValue::new(), 2);
+        let mut map2: Map<i32, u64> = Map::from_state(Map::new().clone_state(), 2);
         let remote_op1 = map1.insert(123, 2222).unwrap();
         let remote_op2 = map1.remove(&123).unwrap();
         let _ = map2.execute_remote(&remote_op1).unwrap();
@@ -530,7 +530,7 @@ mod tests {
     #[test]
     fn test_execute_remote_remove_does_not_exist() {
         let mut map1: Map<i32, u64> = Map::new();
-        let mut map2: Map<i32, u64> = Map::from_value(MapValue::new(), 2);
+        let mut map2: Map<i32, u64> = Map::from_state(Map::new().clone_state(), 2);
         let _ = map1.insert(123, 2222);
         let remote_op = map1.remove(&123).unwrap();
         assert!(map2.execute_remote(&remote_op).is_none());
@@ -539,8 +539,8 @@ mod tests {
     #[test]
     fn test_execute_remote_remove_some_replicas_remain() {
         let mut map1: Map<i32, u64> = Map::new();
-        let mut map2: Map<i32, u64> = Map::from_value(MapValue::new(), 2);
-        let mut map3: Map<i32, u64> = Map::from_value(MapValue::new(), 3);
+        let mut map2: Map<i32, u64> = Map::from_state(Map::new().clone_state(), 2);
+        let mut map3: Map<i32, u64> = Map::from_state(Map::new().clone_state(), 3);
         let remote_op1 = map2.insert(123, 1111).unwrap();
         let remote_op2 = map1.insert(123, 2222).unwrap();
         let remote_op3 = map1.remove(&123).unwrap();
@@ -556,7 +556,7 @@ mod tests {
     #[test]
     fn test_execute_remote_remove_dupe() {
         let mut map1: Map<i32, u64> = Map::new();
-        let mut map2: Map<i32, u64> = Map::from_value(MapValue::new(), 2);
+        let mut map2: Map<i32, u64> = Map::from_state(Map::new().clone_state(), 2);
         let remote_op1 = map1.insert(123, 2222).unwrap();
         let remote_op2 = map1.remove(&123).unwrap();
 
@@ -573,7 +573,7 @@ mod tests {
         let _ = map1.remove(&2);
         let _ = map1.insert(3, true);
 
-        let mut map2 = Map::from_value(map1.clone_value(), 2);
+        let mut map2 = Map::from_state(map1.clone_state(), 2);
         let _ = map2.remove(&3);
         let _ = map2.insert(4, true);
         let _ = map2.remove(&4);
@@ -605,7 +605,7 @@ mod tests {
 
     #[test]
     fn test_add_site() {
-        let mut map: Map<i32, u64> = Map::from_value(MapValue::new(), 0);
+        let mut map: Map<i32, u64> = Map::from_state(Map::new().clone_state(), 0);
         let _ = map.insert(10, 56);
         let _ = map.insert(20, 57);
         let _ = map.remove(&10);
@@ -625,7 +625,7 @@ mod tests {
 
     #[test]
     fn test_add_site_already_has_site() {
-        let mut map: Map<i32, u64> = Map::from_value(MapValue::new(), 123);
+        let mut map: Map<i32, u64> = Map::from_state(Map::new().clone_state(), 123);
         let _ = map.insert(10, 56).unwrap();
         let _ = map.insert(20, 57).unwrap();
         let _ = map.remove(&10).unwrap();

--- a/src/register.rs
+++ b/src/register.rs
@@ -212,8 +212,8 @@ mod tests {
     #[test]
     fn test_execute_remote_concurrent() {
         let mut register1: Register<&'static str> = Register::new("a");
-        let mut register2: Register<&'static str> = Register::from_value(register1.clone_value(), 2);
-        let mut register3: Register<&'static str> = Register::from_value(register1.clone_value(), 3);
+        let mut register2: Register<&'static str> = Register::from_state(register1.clone_state(), 2);
+        let mut register3: Register<&'static str> = Register::from_state(register1.clone_state(), 3);
 
         let remote_op1 = register1.update("b").unwrap();
         let remote_op2 = register2.update("c").unwrap();
@@ -228,7 +228,7 @@ mod tests {
     #[test]
     fn test_execute_remote_dupe() {
         let mut register1: Register<&'static str> = Register::new("a");
-        let mut register2 = Register::from_value(register1.clone_value(), 2);
+        let mut register2 = Register::from_state(register1.clone_state(), 2);
 
         let remote_op = register1.update("b").unwrap();
         let local_op = register2.execute_remote(&remote_op).unwrap();
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn test_merge() {
         let mut register1 = Register::new(123);
-        let mut register2 = Register::from_value(register1.clone_value(), 2);
+        let mut register2 = Register::from_state(register1.clone_state(), 2);
         let _ = register1.update(456);
         let _ = register2.update(789);
         register1.merge(register2.clone_state());
@@ -255,7 +255,7 @@ mod tests {
     #[test]
     fn test_add_site() {
         let mut register1 = Register::new(123);
-        let mut register2 = Register::from_value(register1.clone_value(), 0);
+        let mut register2 = Register::from_state(register1.clone_state(), 0);
         assert!(register2.update(456).unwrap_err() == Error::AwaitingSite);
 
         let remote_ops = register2.add_site(2).unwrap();
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_add_site_already_has_site() {
-        let mut register = Register::from_value(RegisterValue::new(123, &Replica{site: 42, counter: 0}), 42);
+        let mut register = Register::from_state(Register::new(123).clone_state(), 42);
         assert!(register.add_site(44).unwrap_err() == Error::AlreadyHasSite);
     }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -279,7 +279,7 @@ mod tests {
     #[test]
     fn test_insert_awaiting_site() {
         let set1: Set<u32> = Set::new();
-        let mut set2: Set<u32> = Set::from_value(set1.clone_value(), 0);
+        let mut set2: Set<u32> = Set::from_state(set1.clone_state(), 0);
         assert!(set2.insert(123).unwrap_err() == Error::AwaitingSite);
         assert!(set2.contains(&123));
     }
@@ -306,7 +306,7 @@ mod tests {
     #[test]
     fn test_remove_awaiting_site() {
         let set1: Set<u32> = Set::new();
-        let mut set2: Set<u32> = Set::from_value(set1.clone_value(), 0);
+        let mut set2: Set<u32> = Set::from_state(set1.clone_state(), 0);
         let _ = set2.insert(123);
         assert!(set2.remove(&123).unwrap_err() == Error::AwaitingSite);
         assert!(!set2.contains(&123));
@@ -315,7 +315,7 @@ mod tests {
     #[test]
     fn test_site() {
         let set1: Set<u64> = Set::new();
-        let set2: Set<u64> = Set::from_value(set1.clone_value(), 8403);
+        let set2: Set<u64> = Set::from_state(set1.clone_state(), 8403);
         assert!(set1.site() == 1);
         assert!(set2.site() == 8403);
     }
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn execute_remote_insert() {
         let mut set1: Set<u64> = Set::new();
-        let mut set2: Set<u64> = Set::from_value(set1.clone_value(), 8403);
+        let mut set2: Set<u64> = Set::from_state(set1.clone_state(), 8403);
         let remote_op = set1.insert(22).unwrap();
         let local_op = set2.execute_remote(&remote_op).unwrap();
         assert_matches!(local_op, LocalOp::Insert(22));
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn execute_remote_insert_value_already_exists() {
         let mut set1: Set<u64> = Set::new();
-        let mut set2: Set<u64> = Set::from_value(set1.clone_value(), 2);
+        let mut set2: Set<u64> = Set::from_state(set1.clone_state(), 2);
         let remote_op = set1.insert(22).unwrap();
         let _         = set2.insert(22).unwrap();
 
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn execute_remote_insert_dupe() {
         let mut set1: Set<u64> = Set::new();
-        let mut set2: Set<u64> = Set::from_value(set1.clone_value(), 2);
+        let mut set2: Set<u64> = Set::from_state(set1.clone_state(), 2);
         let remote_op = set1.insert(22).unwrap();
 
         assert!(set2.execute_remote(&remote_op).is_some());
@@ -355,7 +355,7 @@ mod tests {
     fn execute_remote_remove() {
         let mut set1: Set<u64> = Set::new();
         let _ = set1.insert(10).unwrap();
-        let mut set2: Set<u64> = Set::from_value(set1.clone_value(), 2);
+        let mut set2: Set<u64> = Set::from_state(set1.clone_state(), 2);
         let remote_op = set1.remove(&10).unwrap();
         let local_op = set2.execute_remote(&remote_op).unwrap();
 
@@ -366,7 +366,7 @@ mod tests {
     #[test]
     fn execute_remote_remove_does_not_exist() {
         let mut set1: Set<u64> = Set::new();
-        let mut set2: Set<u64> = Set::from_value(set1.clone_value(), 2);
+        let mut set2: Set<u64> = Set::from_state(set1.clone_state(), 2);
         let _ = set1.insert(10).unwrap();
         let remote_op = set1.remove(&10).unwrap();
         assert!(set2.execute_remote(&remote_op).is_none());
@@ -376,7 +376,7 @@ mod tests {
     #[test]
     fn execute_remote_remove_some_replicas_remain() {
         let mut set1: Set<u64> = Set::new();
-        let mut set2: Set<u64> = Set::from_value(set1.clone_value(), 2);
+        let mut set2: Set<u64> = Set::from_state(set1.clone_state(), 2);
         let _ = set1.insert(10).unwrap();
         let _ = set2.insert(10).unwrap();
         let remote_op = set1.remove(&10).unwrap();
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn execute_remote_remove_dupe() {
         let mut set1: Set<u64> = Set::new();
-        let mut set2: Set<u64> = Set::from_value(set1.clone_value(), 2);
+        let mut set2: Set<u64> = Set::from_state(set1.clone_state(), 2);
         let remote_op1 = set1.insert(10).unwrap();
         let remote_op2 = set1.remove(&10).unwrap();
         assert!(set2.execute_remote(&remote_op1).is_some());
@@ -403,7 +403,7 @@ mod tests {
         let _ = set1.insert(2);
         let _ = set1.remove(&2);
 
-        let mut set2 = Set::from_value(set1.clone_value(), 2);
+        let mut set2 = Set::from_state(set1.clone_state(), 2);
         let _ = set1.insert(3);
         let _ = set2.insert(3);
         let _ = set2.insert(4);
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn test_add_site() {
-        let mut set: Set<u64> = Set::from_value(Set::new().clone_value(), 0);
+        let mut set: Set<u64> = Set::from_state(Set::new().clone_state(), 0);
         let _ = set.insert(10);
         let _ = set.insert(20);
         let _ = set.remove(&10);
@@ -447,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_add_site_already_has_site() {
-        let mut set: Set<u64> = Set::from_value(Set::new().clone_value(), 123);
+        let mut set: Set<u64> = Set::from_state(Set::new().clone_state(), 123);
         let _ = set.insert(10);
         let _ = set.insert(20);
         let _ = set.remove(&10);

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_insert_remove_awaiting_site() {
-        let mut text = Text::from_value(TextValue::new(), 0);
+        let mut text = Text::from_state(Text::new().clone_state(), 0);
         assert!(text.insert(0, "Hello".to_owned()).unwrap_err() == Error::AwaitingSite);
         assert!(text.remove(0, 1).unwrap_err() == Error::AwaitingSite);
         assert!(text.local_value() == "ello");
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn test_execute_remote() {
         let mut text1 = Text::new();
-        let mut text2 = Text::from_value(text1.clone_value(), 0);
+        let mut text2 = Text::from_state(text1.clone_state(), 0);
 
         let remote_op1 = text1.insert(0, "hello".to_owned()).unwrap();
         let remote_op2 = text1.remove(0, 1).unwrap();
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn test_execute_remote_dupe() {
         let mut text1 = Text::new();
-        let mut text2 = Text::from_value(text1.clone_value(), 0);
+        let mut text2 = Text::from_state(text1.clone_state(), 0);
         let remote_op = text1.insert(0, "hello".to_owned()).unwrap();
         assert!(text2.execute_remote(&remote_op).is_some());
         assert!(text2.execute_remote(&remote_op).is_none());
@@ -225,7 +225,7 @@ mod tests {
         let _ = text1.insert(16, "fox".to_owned());
         let _ = text1.remove(4, 6);
 
-        let mut text2 = Text::from_value(text1.clone_value(), 2);
+        let mut text2 = Text::from_state(text1.clone_state(), 2);
         let _ = text2.remove(4, 6);
         let _ = text2.insert(4, "yellow ".to_owned());
         let _ = text1.insert(4, "slow ".to_owned());
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_add_site() {
-        let mut text = Text::from_value(TextValue::new(), 0);
+        let mut text = Text::from_state(Text::new().clone_state(), 0);
         let _ = text.insert(0, "hello".to_owned());
         let _ = text.insert(5, "there".to_owned());
         let _ = text.remove(4, 1);
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn test_add_site_already_has_site() {
-        let mut text = Text::from_value(TextValue::new(), 123);
+        let mut text = Text::from_state(Text::new().clone_state(), 123);
         let _ = text.insert(0, "hello".to_owned()).unwrap();
         let _ = text.insert(5, "there".to_owned()).unwrap();
         let _ = text.remove(4, 1).unwrap();
@@ -315,7 +315,7 @@ mod tests {
     #[test]
     fn test_serialize_local_op() {
         let mut text1 = Text::new();
-        let mut text2 = Text::from_value(text1.clone_value(), 2);
+        let mut text2 = Text::from_state(text1.clone_state(), 2);
         let remote_op1 = text1.insert(0, "hello".to_owned()).unwrap();
         let remote_op2 = text1.insert(2, "bonjour".to_owned()).unwrap();
         let _ = text2.execute_remote(&remote_op1).unwrap();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -18,22 +18,6 @@ macro_rules! crdt_impl {
         }
 
         /// Clones the CRDT's inner value.
-        pub fn clone_value(&self) -> $value {
-            self.value.clone()
-        }
-
-        /// Constructs a new CRDT from a value and a site.
-        /// This CRDT cannot be used for state-based  merges.
-        pub fn from_value(value: $value, site: u32) -> Self {
-            $tipe{
-                replica: Replica{site, counter: 0},
-                value: value,
-                tombstones: Tombstones::new(),
-                awaiting_site: vec![],
-            }
-        }
-
-        /// Clones the CRDT's inner value.
         pub fn clone_state(&self) -> $state {
             $state_ident{value: self.value.clone(), tombstones: self.tombstones.clone()}
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,8 +10,8 @@ use ditto::{list, map, set};
 #[test]
 fn test_list() {
     let mut list1: List<i64> = List::new();
-    let mut list2: List<i64> = List::from_value(list1.clone_value(), 2);
-    let mut list3: List<i64> = List::from_value(list1.clone_value(), 3);
+    let mut list2: List<i64> = List::from_state(list1.clone_state(), 2);
+    let mut list3: List<i64> = List::from_state(list1.clone_state(), 3);
 
     let remote_op1 = list1.insert(0, 5).unwrap();
     let remote_op2 = list2.insert(0, 10).unwrap();
@@ -44,8 +44,8 @@ fn test_list() {
 #[test]
 fn test_map() {
     let mut map1: Map<i32, bool> = Map::new();
-    let mut map2: Map<i32, bool> = Map::from_value(map1.clone_value(), 2);
-    let mut map3: Map<i32, bool> = Map::from_value(map1.clone_value(), 3);
+    let mut map2: Map<i32, bool> = Map::from_state(map1.clone_state(), 2);
+    let mut map3: Map<i32, bool> = Map::from_state(map1.clone_state(), 3);
 
     let remote_op1 = map1.insert(0, true).unwrap();
     let remote_op2 = map2.insert(0, false).unwrap();
@@ -78,8 +78,8 @@ fn test_map() {
 #[test]
 fn test_register() {
     let mut register1: Register<u32> = Register::new(56);
-    let mut register2: Register<u32> = Register::from_value(register1.clone_value(), 2);
-    let mut register3: Register<u32> = Register::from_value(register1.clone_value(), 3);
+    let mut register2: Register<u32> = Register::from_state(register1.clone_state(), 2);
+    let mut register3: Register<u32> = Register::from_state(register1.clone_state(), 3);
 
     let remote_op1 = register2.update(41).unwrap();
     let remote_op2 = register1.update(32).unwrap();
@@ -107,8 +107,8 @@ fn test_register() {
 #[test]
 fn test_set() {
     let mut set1: Set<i32> = Set::new();
-    let mut set2: Set<i32> = Set::from_value(set1.clone_value(), 2);
-    let mut set3: Set<i32> = Set::from_value(set1.clone_value(), 3);
+    let mut set2: Set<i32> = Set::from_state(set1.clone_state(), 2);
+    let mut set3: Set<i32> = Set::from_state(set1.clone_state(), 3);
 
     let remote_op1 = set1.insert(10).unwrap();
     let remote_op2 = set2.insert(10).unwrap();
@@ -142,8 +142,8 @@ fn test_set() {
 #[test]
 fn test_text() {
     let mut text1 = Text::new();
-    let mut text2 = Text::from_value(text1.clone_value(), 2);
-    let mut text3 = Text::from_value(text1.clone_value(), 3);
+    let mut text2 = Text::from_state(text1.clone_state(), 2);
+    let mut text3 = Text::from_state(text1.clone_state(), 3);
 
     let remote_op1 = text1.insert(0, "Hello! ".to_owned()).unwrap();
     let remote_op2 = text2.insert(0, "Bonjour. ".to_owned()).unwrap();
@@ -163,8 +163,8 @@ fn test_text() {
 #[test]
 fn test_json() {
     let mut crdt1 = Json::from_str("{}").unwrap();
-    let mut crdt2 = Json::from_value(crdt1.clone_value(), 2);
-    let mut crdt3 = Json::from_value(crdt1.clone_value(), 3);
+    let mut crdt2 = Json::from_state(crdt1.clone_state(), 2);
+    let mut crdt3 = Json::from_state(crdt1.clone_state(), 3);
 
     let remote_op1 = crdt1.object_insert("", "foo".to_owned(), 1.0).unwrap();
     let remote_op2 = crdt2.object_insert("", "foo".to_owned(), 2.0).unwrap();


### PR DESCRIPTION
CRDT state is now passed over the network via the various CrdtState structures.
There is no more need to expose the various CrdtValue structures.