### PR TITLE
Fix unreachable bug

### DIFF
--- a/src/text/btree.rs
+++ b/src/text/btree.rs
@@ -136,15 +136,13 @@ impl Node {
             let median   = child.elements.pop().expect("Element must exist A!");
             let children = if child.is_leaf() { vec![] } else { child.children.split_off(B) };
 
-            child.len =
-                child.elements.iter().fold(0, |sum, e| sum + e.len) +
-                child.children.iter().fold(0, |sum, e| sum + e.len);
-
             let new_child_len =
                 elements.iter().fold(0, |sum, e| sum + e.len) +
                 children.iter().fold(0, |sum, e| sum + e.len);
 
             let new_child = Node{len: new_child_len, elements, children};
+
+            child.len -= new_child_len + median.len;
 
             (median, new_child)
         };
@@ -182,17 +180,20 @@ impl Node {
     /// elements)
     fn insert(&mut self, elt: Element) -> Result<(), Error> {
         let mut index = self.elements.binary_search(&elt).err().ok_or(Error::DuplicateUID)?;
-        self.len += elt.len;
+        let elt_len = elt.len;
+
         if self.is_leaf() {
             self.elements.insert(index, elt);
-            Ok(())
         } else {
             if self.children[index].is_full() {
                 self.split_child(index);
                 if elt > self.elements[index] { index += 1 }
             }
-            self.children[index].insert(elt)
+            self.children[index].insert(elt)?;
         }
+
+        self.len += elt_len;
+        Ok(())
     }
 
     /// Delete an element from a tree, returning the removed element.
@@ -494,6 +495,24 @@ mod tests {
     }
 
     #[test]
+    fn insert_duplicate() {
+        let mut btree = BTree::new();
+
+        for _ in 0..300 {
+            insert_random(&mut btree, "I");
+        }
+
+        let element1 = remove_at(&mut btree, 50);
+        let element2 = element1.clone();
+
+        btree.insert(element1).unwrap();
+        assert!(btree.len() == 300);
+
+        btree.insert(element2).unwrap_err();
+        assert!(btree.len() == 300);
+    }
+
+    #[test]
     fn insert_emoji() {
         let mut btree = BTree::new();
         insert_at(&mut btree, 0, "hello");
@@ -518,6 +537,21 @@ mod tests {
         assert!(btree.root.is_leaf());
         assert!(btree.root.elements[0].text == "hello");
         assert!(btree.root.elements[1].text == "goodbye");
+    }
+
+    #[test]
+    fn remove_duplicate() {
+        let mut btree = BTree::new();
+
+        for _ in 0..300 {
+            insert_random(&mut btree, "I");
+        }
+
+        let element = remove_at(&mut btree, 100);
+        assert!(btree.len() == 299);
+
+        assert!(btree.remove(&element.uid).is_none());
+        assert!(btree.len() == 299);
     }
 
     #[test]


### PR DESCRIPTION
Bug: When inserting an element recursively, the outer node would update its length BEFORE recursing. This led to an invalid node length whenever an element was discovered to be a duplicate in a recursive call.

Fix: Update node length AFTER recursive calls succeed.