### PR TITLE
cache remove-before-insert ops

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -180,7 +180,7 @@ impl Json {
         JsonState,
         Inner,
         Op,
-        Option<LocalOp>,
+        LocalOp,
         SJValue,
     }
 }
@@ -268,7 +268,7 @@ impl Inner {
             }
             OpInner::String(op) => {
                 let changes = inner.as_text().ok()?.execute_op(op);
-                if changes.is_empty() { return vec![] };
+                if changes.is_empty() { return None };
                 Some(LocalOp::ReplaceText{pointer, changes})
             }
         }

--- a/src/json.rs
+++ b/src/json.rs
@@ -246,7 +246,7 @@ impl Inner {
                 match map_inner.execute_op(op) {
                     map::LocalOp::Insert{key, value} => {
                         pointer.push(LocalUid::Object(key));
-                        Some(LocalOp::Insert{pointer, value: value.local_value()}])
+                        Some(LocalOp::Insert{pointer, value: value.local_value()})
                     }
                     map::LocalOp::Remove{key} => {
                         pointer.push(LocalUid::Object(key));
@@ -258,7 +258,7 @@ impl Inner {
                 match inner.as_list().ok()?.execute_op(op)? {
                     list::LocalOp::Insert{idx, value} => {
                         pointer.push(LocalUid::Array(idx));
-                        Some(LocalOp::Insert{pointer, value: value.local_value()}])
+                        Some(LocalOp::Insert{pointer, value: value.local_value()})
                     }
                     list::LocalOp::Remove{idx} => {
                         pointer.push(LocalUid::Array(idx));

--- a/src/json.rs
+++ b/src/json.rs
@@ -33,11 +33,11 @@ use std::str::FromStr;
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Json {
-    inner:          Inner,
-    summary:        Summary,
-    site_id:        SiteId,
+    inner:      Inner,
+    summary:    Summary,
+    site_id:    SiteId,
+    cached_ops: Vec<Op>,
     outoforder_ops: Vec<Op>,
-    cached_ops:     Vec<Op>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/list.rs
+++ b/src/list.rs
@@ -32,10 +32,11 @@ use std::cmp::Ordering;
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct List<T: 'static> {
-    inner:      Inner<T>,
-    summary:    Summary,
-    site_id:    SiteId,
-    cached_ops: Vec<Op<T>>,
+    inner:          Inner<T>,
+    summary:        Summary,
+    site_id:        SiteId,
+    outoforder_ops: Vec<Op<T>>,
+    cached_ops:     Vec<Op<T>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -92,7 +93,7 @@ impl<T: Clone> List<T> {
         let inner   = Inner::new();
         let summary = Summary::default();
         let site_id = 1;
-        List{inner, summary, site_id, cached_ops: vec![]}
+        List{inner, summary, site_id, outoforder_ops: vec![], cached_ops: vec![]}
     }
 
     /// Returns the number of elements in the list.
@@ -421,6 +422,13 @@ impl<T> Op<T> {
             vec![Dot::new(elt.uid.site_id, elt.uid.counter)]
         } else {
             vec![]
+        }
+    }
+
+    pub(crate) fn removed_dots(&self) -> Vec<Dot> {
+        match *self {
+            Op::Insert(_) => vec![],
+            Op::Remove(ref uid) => vec![uid.dot()],
         }
     }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -32,11 +32,11 @@ use std::cmp::Ordering;
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct List<T: 'static> {
-    inner:          Inner<T>,
-    summary:        Summary,
-    site_id:        SiteId,
+    inner:      Inner<T>,
+    summary:    Summary,
+    site_id:    SiteId,
+    cached_ops: Vec<Op<T>>,
     outoforder_ops: Vec<Op<T>>,
-    cached_ops:     Vec<Op<T>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/list.rs
+++ b/src/list.rs
@@ -159,7 +159,7 @@ impl<T: Clone> List<T> {
         ListState,
         Inner<T>,
         Op<T>,
-        Option<LocalOp<T>>,
+        LocalOp<T>,
         Vec<T>,
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -44,11 +44,11 @@ impl<T: Clone + PartialEq + Serialize + DeserializeOwned> Value for T {}
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(bound(deserialize = ""))]
 pub struct Map<K: Key, V: Value> {
-    inner:          Inner<K, V>,
-    summary:        Summary,
-    site_id:        SiteId,
+    inner:      Inner<K, V>,
+    summary:    Summary,
+    site_id:    SiteId,
+    cached_ops: Vec<Op<K, V>>,
     outoforder_ops: Vec<Op<K, V>>,
-    cached_ops:     Vec<Op<K, V>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/map.rs
+++ b/src/map.rs
@@ -44,10 +44,11 @@ impl<T: Clone + PartialEq + Serialize + DeserializeOwned> Value for T {}
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(bound(deserialize = ""))]
 pub struct Map<K: Key, V: Value> {
-    inner:      Inner<K, V>,
-    summary:    Summary,
-    site_id:    SiteId,
-    cached_ops: Vec<Op<K, V>>,
+    inner:          Inner<K, V>,
+    summary:        Summary,
+    site_id:        SiteId,
+    outoforder_ops: Vec<Op<K, V>>,
+    cached_ops:     Vec<Op<K, V>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -109,7 +110,7 @@ impl<K: Key, V: Value> Map<K, V> {
         let inner   = Inner::new();
         let summary = Summary::default();
         let site_id = 1;
-        Map{inner, summary, site_id, cached_ops: vec![]}
+        Map{inner, summary, site_id, outoforder_ops: vec![], cached_ops: vec![]}
     }
 
     /// Returns true iff the map has the key.
@@ -149,7 +150,7 @@ impl<K: Key, V: Value> Map<K, V> {
         MapState,
         Inner<K, V>,
         Op<K, V>,
-        LocalOp<K, V>,
+        Option<LocalOp<K, V>>,
         HashMap<K, V>,
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -150,7 +150,7 @@ impl<K: Key, V: Value> Map<K, V> {
         MapState,
         Inner<K, V>,
         Op<K, V>,
-        Option<LocalOp<K, V>>,
+        LocalOp<K, V>,
         HashMap<K, V>,
     }
 }
@@ -379,7 +379,7 @@ impl<K: Key, V: Value> Op<K, V> {
     pub fn inserted_element(&self) -> Option<&Element<V>> { self.inserted_element.as_ref() }
 
     /// Returns a reference to the `Op`'s removed dots.
-    pub fn removed_dots(&self) -> &[Dot] { &self.removed_dots }
+    pub fn removed_dots(&self) -> Vec<Dot> { self.removed_dots.clone() }
 
     /// Assigns a site id to any unassigned inserts and removes
     pub fn add_site_id(&mut self, site_id: SiteId) {

--- a/src/set.rs
+++ b/src/set.rs
@@ -41,11 +41,11 @@ impl<T: Clone + Eq + Hash + Serialize + DeserializeOwned> SetElement for T {}
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(bound(deserialize = ""))]
 pub struct Set<T: SetElement> {
-    inner:          Inner<T>,
-    summary:        Summary,
-    site_id:        SiteId,
+    inner:      Inner<T>,
+    summary:    Summary,
+    site_id:    SiteId,
+    cached_ops: Vec<Op<T>>,
     outoforder_ops: Vec<Op<T>>,
-    cached_ops:     Vec<Op<T>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/set.rs
+++ b/src/set.rs
@@ -113,7 +113,7 @@ impl<T: SetElement> Set<T> {
         SetState,
         Inner<T>,
         Op<T>,
-        Option<LocalOp<T>>,
+        LocalOp<T>,
         HashSet<T>,
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -41,10 +41,11 @@ impl<T: Clone + Eq + Hash + Serialize + DeserializeOwned> SetElement for T {}
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(bound(deserialize = ""))]
 pub struct Set<T: SetElement> {
-    inner:      Inner<T>,
-    summary:    Summary,
-    site_id:    SiteId,
-    cached_ops: Vec<Op<T>>,
+    inner:          Inner<T>,
+    summary:        Summary,
+    site_id:        SiteId,
+    outoforder_ops: Vec<Op<T>>,
+    cached_ops:     Vec<Op<T>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -78,7 +79,7 @@ impl<T: SetElement> Set<T> {
         let inner   = Inner::new();
         let summary = Summary::default();
         let site_id = 1;
-        Set{inner, summary, site_id, cached_ops: vec![]}
+        Set{inner, summary, site_id, outoforder_ops: vec![], cached_ops: vec![]}
     }
 
     /// Returns true iff the set contains the value.

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -38,11 +38,11 @@ lazy_static! {
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Text {
-    inner:          Inner,
-    site_id:        SiteId,
-    summary:        Summary,
+    inner:      Inner,
+    site_id:    SiteId,
+    summary:    Summary,
+    cached_ops: Vec<Op>,
     outoforder_ops: Vec<Op>,
-    cached_ops:     Vec<Op>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -38,10 +38,11 @@ lazy_static! {
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Text {
-    inner:      Inner,
-    site_id:    SiteId,
-    summary:    Summary,
-    cached_ops: Vec<Op>,
+    inner:          Inner,
+    site_id:        SiteId,
+    summary:        Summary,
+    outoforder_ops: Vec<Op>,
+    cached_ops:     Vec<Op>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -77,7 +78,7 @@ impl Text {
         let inner   = Inner::new();
         let summary = Summary::default();
         let site_id = 1;
-        Text{inner, summary, site_id, cached_ops: vec![]}
+        Text{inner, summary, site_id, outoforder_ops: vec![], cached_ops: vec![]}
     }
 
     /// Constructs and returns a new Text CRDT from a string.
@@ -117,7 +118,7 @@ impl Text {
         TextState,
         Inner,
         Op,
-        Vec<LocalOp>,
+        LocalOp,
         String,
     }
 }
@@ -356,6 +357,10 @@ impl Op {
 
     pub fn inserted_dots(&self) -> Vec<Dot> {
         self.inserted_elements.iter().map(|elt| elt.uid.dot()).collect()
+    }
+
+    pub fn removed_dots(&self) -> Vec<Dot> {
+        self.removed_uids.iter().map(|uid| uid.dot()).collect()
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
Right now, Ditto discards any REMOVE op that is received before its corresponding INSERT op. This leads to inconsistencies in the following case:

site1: INSERT(A) -> op1
site2: EXECUTE(op1)
site2: REMOVE(A) -> op2
site3: EXECUTE(op2)
site3: EXECUTE(op1)

This PR fixes the bug by caching any REMOVE op received before its corresponding INSERT op and executing the REMOVE op once the INSERT has been executed.