### PR TITLE
Add iterator to List, Set and Map

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -65,12 +65,6 @@ pub struct Element<T> {
     pub value: T,
 }
 
-#[derive(Debug)]
-pub struct Iter<'a, T:'static + Clone> {
-    idx: usize,
-    list: &'a List<T>,
-}
-
 impl<T> PartialEq for Element<T> {
     fn eq(&self, other: &Element<T>) -> bool {
         self.uid == other.uid
@@ -158,11 +152,8 @@ impl<T: Clone> List<T> {
     }
 
     /// Returns an `Iterator` over references to elements in the list
-    pub fn iter(&self) -> Iter<T> {
-        Iter {
-            idx: 0,
-            list: &self,
-        }
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.inner.iter().map(|e| &e.value)
     }
 
     crdt_impl2! {
@@ -458,19 +449,5 @@ impl<T: NestedInner> NestedOp for Op<T> {
             elt.value.nested_validate_all(site_id)?;
         }
         Ok(())
-    }
-}
-
-impl<'a, T: Clone> Iterator for Iter<'a, T> {
-    type Item = &'a T;
-    fn next(&mut self) -> Option<Self::Item> {
-        // `List::get` performs a bounds check for us, no need to do it twice
-        let res = self.list.get(self.idx);
-        if res.is_some() {
-            // res will be `None` if out of bounds
-            // only increment while still in bounds
-            self.idx += 1
-        }
-        res
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -142,6 +142,11 @@ impl<K: Key, V: Value> Map<K, V> {
         Some(self.after_op(op))
     }
 
+    /// Returns an `Iterator` over references to elements in the map
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.inner.iter().map(|(k, v)| (k, &(v[0].value)))
+    }
+
     crdt_impl2! {
         Map,
         MapState<K, V>,

--- a/src/set.rs
+++ b/src/set.rs
@@ -105,6 +105,11 @@ impl<T: SetElement> Set<T> {
         Some(self.after_op(op))
     }
 
+    /// Returns an `Iterator` over references to elements in the set
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.inner.iter()
+    }
+
     crdt_impl2! {
         Set,
         SetState<T>,
@@ -204,6 +209,10 @@ impl<T: SetElement> Inner<T> {
             }
         }
         Ok(())
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &T> {
+        self.0.keys()
     }
 
 

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -274,3 +274,49 @@ fn test_serialize_local_op() {
     common::test_serde(op1);
     common::test_serde(op2);
 }
+
+#[test]
+fn test_iter() {
+    let mut list: List<u8> = List::new();
+
+    {
+        let mut iter = list.iter();
+        assert_eq!(None, iter.next()); // nothing in the list
+        assert_eq!(None, iter.next()); // double check.. still nothing
+    }
+
+    list.push(0).unwrap();
+
+    {
+        let mut iter = list.iter();
+        assert_eq!(Some(&0), iter.next());
+        assert_eq!(None, iter.next());
+    }
+
+    list.push(1).unwrap();
+
+    {
+        let mut iter = list.iter();
+        assert_eq!(Some(&0), iter.next());
+        assert_eq!(Some(&1), iter.next());
+        assert_eq!(None, iter.next());
+    }
+
+    list.pop().unwrap();
+    list.pop().unwrap();
+    assert_eq!(list.len(), 0);
+
+    list.push(0).unwrap();
+    list.push(2).unwrap();
+    list.push(4).unwrap();
+    list.push(12).unwrap();
+    list.push(6).unwrap();
+
+    // map, filter, zip.. etc come predefined with the Iterator trait
+    let iter_0123 = list.iter() //=> &0 &2 &4 &12 &6
+        .map(|&x| x / 2)        //=> 0 1 2 6 3 (a clone happens here)
+        .filter(|&x| x <= 3);   //=> 0 1 2 3
+    for (a, b) in iter_0123.zip(0..3u8) {
+        assert_eq!(a, b);
+    }
+}

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -316,7 +316,7 @@ fn test_iter() {
     let iter_0123 = list.iter() //=> &0 &2 &4 &12 &6
         .map(|&x| x / 2)        //=> 0 1 2 6 3 (a clone happens here)
         .filter(|&x| x <= 3);   //=> 0 1 2 3
-    for (a, b) in iter_0123.zip(0..3u8) {
+    for (a, b) in iter_0123.zip(0..=3u8) {
         assert_eq!(a, b);
     }
 }

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -263,3 +263,31 @@ fn test_serialize_local_op() {
     common::test_serde(op1);
     common::test_serde(op2);
 }
+
+#[test]
+fn test_iter() {
+    let mut map: Map<String, u8> = Map::new();
+
+    {
+        let mut iter = map.iter();
+        assert_eq!(None, iter.next()); // nothing in the map
+        assert_eq!(None, iter.next()); // double check.. still nothing
+    }
+
+    map.insert("dylan".into(), 21).unwrap();
+
+    {
+        let mut iter = map.iter();
+        assert_eq!(Some((&"dylan".into(), &21)), iter.next());
+        assert_eq!(None, iter.next());
+    }
+
+    map.insert("theresa".into(), 45).unwrap();
+
+    {
+        let mut iter_vec: Vec<(&String, &u8)> = map.iter().collect();
+        iter_vec.sort();
+        
+        assert_eq!(iter_vec, [(&"dylan".into(), &21), (&"theresa".into(), &45)]);
+    }
+}

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -261,3 +261,31 @@ fn test_serialize_local_op() {
     let op = set1.insert(123).unwrap();
     common::test_serde(set2.execute_op(op).unwrap());
 }
+
+#[test]
+fn test_iter() {
+    let mut set :Set<u8> = Set::new();
+
+    {
+        let mut iter = set.iter();
+        assert_eq!(None, iter.next()); // nothing in the set
+        assert_eq!(None, iter.next()); // double check.. still nothing
+    }
+
+    set.insert(0).unwrap();
+
+    {
+        let mut iter = set.iter();
+        assert_eq!(Some(&0), iter.next());
+        assert_eq!(None, iter.next());
+    }
+
+    set.insert(1).unwrap();
+
+    {
+        let mut iter_vec: Vec<&u8> = set.iter().collect();
+        iter_vec.sort();
+
+        assert_eq!(iter_vec, [&0, &1]);
+    }
+}


### PR DESCRIPTION
Adds `List::iter(&self)`

I'll likely be wanting iterators for Set and Map soon as well, I'll send PR's as needs come up